### PR TITLE
Add a Read-Me

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Filer
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A file manager and re-implementation of macOS's [Finder](https://en.wikipedia.org/wiki/Finder_(software)).  A key component of [ravynOS](https://www.ravynos.com/), Filer is the first application you see after you start ravynOS up and finish logging in.  It opens automatically and stays open as you use other apps.  It includes Filer's menus in the menu bar at the top of the screen and the filesystem contents of the desktop below that.  It uses windows and icons to show you the contents of your device and other storage.  


### PR DESCRIPTION
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This PR creates a read-me for this repository by adapting some wording from [helloSystem's Filer's read-me](https://github.com/helloSystem/Filer/blob/master/README.md) and the introduction to [Apple's short online Finder help page](https://support.apple.com/en-us/HT201732) for it.  Whether it's kept around when this repository gets merged into the main ravynOS one or not is something I'll leave up in the air (though I'll note that GitHub automatically displays read-mes it finds in _any_ folder for that directory, not _just_ the repository root, even if that folder isn't a Git submodule.)  

Potential future directions:  
 - Add a build status badge.  
 - Add a sentence at the end of the introduction paralleling the one in the Apple technical note linked above explaining why this project's called 'Filer' or one that refers to a new section of this read-me on naming.  (helloSystem's Filer doesn't have any documentation on how its name got chosen that I could find and we could parallel, though.)  